### PR TITLE
Fix deprecated function for get_the_author_meta

### DIFF
--- a/shortcodes/recent_posts.php
+++ b/shortcodes/recent_posts.php
@@ -123,7 +123,7 @@ function memberlitesc_recent_posts_shortcode_handler($atts, $content=null, $code
 			}
 			else
 			{
-				$author_id = get_the_author_meta('id');
+				$author_id = get_the_author_meta( 'ID' );
 				$r .= '<a class="widget_post_thumbnail" href="' . get_permalink() . '">' . get_avatar( $author_id, 80 ) . '</a>';
 			}
 		}


### PR DESCRIPTION
Changed get_the_author_meta('id') with get_the_author_meta('ID');