### PR TITLE
fix issue #14

### DIFF
--- a/shortcodes/tabs.php
+++ b/shortcodes/tabs.php
@@ -12,6 +12,8 @@ function memberlitesc_tabs_shortcode($atts, $content = null) {
 	
 	//figure out the active tab and store in a global
 	global $post, $memberlite_active_tabs;
+	if ( ! $memberlite_active_tabs ) 
+		$memberlite_active_tabs = array();
 	$cookie_name = 'memberlite_active_tabs_' . $post->ID . '_' . count($memberlite_active_tabs);
 	if(!empty($_COOKIE[$cookie_name]))
 		$cookie_value = $_COOKIE[$cookie_name];


### PR DESCRIPTION
Fix for https://github.com/strangerstudios/memberlite-shortcodes/issues/14

`$cookie_name` requires `$memberlite_active_tabs` to be countable

Fix: Set `$memberlite_active_tabs` as an array if it doesn't exist.