### PR TITLE
adding the esc_ functions to include in localization

### DIFF
--- a/languages/gettext.sh
+++ b/languages/gettext.sh
@@ -17,6 +17,12 @@ xgettext -j -o languages/memberlite-shortcodes.pot \
 --keyword=_ex \
 --keyword=_n \
 --keyword=_x \
+--keyword=esc_html__ \
+--keyword=esc_html_e \
+--keyword=esc_html_x \
+--keyword=esc_attr__ \
+--keyword=esc_attr_e \
+--keyword=esc_attr_x \
 --sort-by-file \
 --package-version=1.1 \
 --msgid-bugs-address="info@paidmembershipspro.com" \


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/memberlite-elements/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite-elements/pulls/) for the same update/change?

This makes sure gettext.sh includes all of the possible localization functions.