### PR TITLE
Removing custom CSS for the pmpro signup shortcode - not needed here

### DIFF
--- a/css/memberlite-shortcodes.css
+++ b/css/memberlite-shortcodes.css
@@ -115,15 +115,11 @@ form.memberlite_signup div {
 }
 form.memberlite_signup input[type=text],
 form.memberlite_signup input[type=email],
-form.memberlite_signup input[type=password],
-form.pmpro_signup_form input[type=text],
-form.pmpro_signup_form input[type=email],
-form.pmpro_signup_form input[type=password] {
+form.memberlite_signup input[type=password] {
 	max-width: 100%;
 	width: 100%;
 }
-form.memberlite_signup .pmpro_btn,
-form.pmpro_signup_form .pmpro_btn {
+form.memberlite_signup .pmpro_btn {
 	display: block;
 	width: 100%;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/memberlite-shortcodes/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite-shortcodes/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Removing styles for the pmpro shortcode - this plugin should only target shortcodes within it.
