### PR TITLE
Prepping v1.4 release: Escaping in Recent Posts shortcode; Deprecating Signup Shortcode

### DIFF
--- a/memberlite-shortcodes.php
+++ b/memberlite-shortcodes.php
@@ -1,18 +1,20 @@
 <?php
-/*
-Plugin Name: Memberlite Shortcodes
-Plugin URI: https://memberlitetheme.com/memberlite-shortcodes/
-Description: Shortcodes designed to work with the Memberlite Theme and Memberlite Child Themes.
-Version: 1.3.9
-Author: Stranger Studios
-Author URI: https://memberlitetheme.com
-Text Domain: memberlite-shortcodes
-Domain Path: /languages
+/**
+ * Plugin Name: Memberlite Shortcodes
+ * Plugin URI: https://memberlitetheme.com/memberlite-shortcodes/
+ * Description: Shortcodes designed to work with the Memberlite Theme and Memberlite Child Themes.
+ * Version: 1.4
+ * Author: Stranger Studios
+ * Author URI: https://memberlitetheme.com
+ * License: GPL-3.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ * Text Domain: memberlite-shortcodes
+ * Domain Path: /languages
 */
 
 define( 'MEMBERLITESC_DIR', dirname( __FILE__ ) );
 define( 'MEMBERLITESC_URL', plugins_url( '', __FILE__ ) );
-define( 'MEMBERLITESC_VERSION', '1.3.9' );
+define( 'MEMBERLITESC_VERSION', '1.4' );
 
 /**
  * Load text domain

--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,12 @@
 === Memberlite Shortcodes ===
 Contributors: kimannwall, strangerstudios
-Tags: theme, shortcodes, memberlite, membership, paid memberships pro
-Requires at least: 5.3
-Tested up to: 6.5
-Stable tag: 1.3.9
-License: GPLv2 or later
-License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Tags: theme, shortcodes, memberlite, membership
+Requires at least: 5.4
+Tested up to: 6.7
+Requires PHP: 5.6
+Stable tag: 1.4
+License: GPLv3
+License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 A set of shortcodes designed enhance the appearance of your content with the Memberlite Theme.
 
@@ -13,7 +14,7 @@ A set of shortcodes designed enhance the appearance of your content with the Mem
 = Shortcodes to enhance the appearance of your membership site =
 For sites running the [Memberlite Theme](https://memberlitetheme.com/) or a Memberlite Child Theme, this plugin offers several shortcodes to simplify the use of various display elements and enhance the appearance of your site content.
 
-[Memberlite](https://memberlitetheme.com) is the ideal theme for your membership site - packed with integration for top membership site plugins including [Paid Memberships Pro](https://wordpress.org/plugins/paid-memberships-pro/). It's fully customizable with your logo, colors, fonts, custom sidebars, and more global layout settings.
+[Memberlite](https://memberlitetheme.com) is the ideal theme for your [Paid Memberships Pro](https://www.paidmembershipspro.com) site. It's fully customizable with your logo, colors, fonts, custom sidebars, and more global layout settings.
 
 = [memberlite_accordion] Shortcode =
 Add an accordion block with collapsible sections using this simple shortcode. [more info](https://memberlitetheme.com/memberlite-shortcodes/accordion/)
@@ -29,9 +30,6 @@ Insert a stylized contextual message block with styling for default, info, alert
 
 = [memberlite_recent_posts] Shortcode =
 Designed to be used on the homepage, this shortcode displays the newest posts or a defined category of posts accoriding to your shortcode settings. [more info](https://memberlitetheme.com/memberlite-shortcodes/recent-posts/)
-
-= [memberlite_signup] Shortcode =
-If you're using [Paid Memberships Pro](https://www.paidmembershipspro.com), this shortcode will display a block with signup fields for a specific membership level. [more info](https://memberlitetheme.com/memberlite-shortcodes/membership-signup-block/)
 
 = [memberlite_subpagelist] Shortcode =
 Easily create a digest view of a given pages' subpages, with an excerpt or the full page content, in the order you define. [more info](https://memberlitetheme.com/memberlite-shortcodes/subpagelist/)
@@ -65,7 +63,6 @@ Browse the Memberlite Shortcodes documentation to see all shortcodes, their attr
 == Screenshots ==
 1. Demo of the Recent Posts shortcode [memberlite_recent_posts] with featured images, excerpts, and a three-column layout.
 2. Demo of the [memberlite_subpagelist] shortcode in a column layout and demo of the [fa] icons.
-3. Demo of the [memberlite_signup] shortcode for a Paid Memberships Pro membership level in a two-column layout using the [memberlite_banner] with the "body" background.
 
 == Frequently Asked Questions ==
 
@@ -79,6 +76,10 @@ Visit https://memberlitetheme.com to get your copy of the Memberlite Theme.
 Some of the shortcodes in this plugin will work with any theme, but we cannot guarantee the appearance will match that of the demo site.
 
 == Changelog ==
+
+= 1.4 - 2024-11-22 =
+* SECURITY: Sanitized and escaped shortcode attributes in the Accordion shortcode.
+* DEPRECATED: Marking the [memberlite_signup] shortcode as deprecated. Use the Signup Shortcode Add On for Paid Memberships Pro instead.
 
 = 1.3.9 - 2023-09-21 =
 * SECURITY: Sanitized and Escaped shortcode attributes and variables.

--- a/readme.txt
+++ b/readme.txt
@@ -78,7 +78,8 @@ Some of the shortcodes in this plugin will work with any theme, but we cannot gu
 == Changelog ==
 
 = 1.4 - 2024-11-22 =
-* SECURITY: Sanitized and escaped shortcode attributes in the Accordion shortcode.
+* SECURITY: Sanitized and escaped shortcode attributes in the Accordion shortcode. (Peter Thaleikis)
+* BUG FIX: Fixed a translation issue in the Recent Posts shortcode.
 * DEPRECATED: Marking the [memberlite_signup] shortcode as deprecated. Use the Signup Shortcode Add On for Paid Memberships Pro instead.
 
 = 1.3.9 - 2023-09-21 =

--- a/shortcodes/recent_posts.php
+++ b/shortcodes/recent_posts.php
@@ -32,10 +32,14 @@ function memberlitesc_recent_posts_shortcode_handler($atts, $content=null, $code
 	);
 
 	// check to see if post type is not empty and the post type exists.
-	if( !empty($post_type) && post_type_exists( $post_type ) ) {
+	if ( ! empty( $post_type ) && post_type_exists( $post_type ) ) {
 		$query_args['post_type'] = $post_type;
-	}else{
-		return _e( "There was a problem fetching content for the post type '$post_type'. Please ensure this exists.", "memberlite-shortcodes" );
+	} else {
+		return sprintf(
+			/* translators: %s: post type */
+			__( "There was a problem fetching content for the post type '%s'. Please ensure this exists.", "memberlite-shortcodes" ),
+			$post_type
+		);
 	}
 
 	if($show_avatar == "0" || $show_avatar == "false" || $show_avatar == "no"){

--- a/shortcodes/signup.php
+++ b/shortcodes/signup.php
@@ -7,110 +7,12 @@
 */
 function memberlitesc_signup_shortcode($atts, $content=null, $code="")
 {
-	// $atts    ::= array of attributes
-	// $content ::= text within enclosing form of shortcode element
-	// $code    ::= the shortcode found, when == callback name
-	// examples: [pmpro_signup level="3" short="1" intro="0" submit_button="Signup Now"]
+	_doing_it_wrong( __FUNCTION__, __( 'The [memberlite_signup] shortcode is now deprecated. Please use the Signup Shortcode Add On for Paid Memberships Pro instead.', 'memberlite-shortcodes' ), '1.4' );
 
-	extract(shortcode_atts(array(
-		'level' => NULL,		
-		'title' => NULL,
-		'short' => NULL,
-		'intro' => NULL,
-		'submit_button' => "Sign Up Now"
-	), $atts));
-	
-	//turn 0's into falses
-	if($short == "0" || $short == "false" || $short == "no")
-		$short = false;
-	
-	if(empty($title))
-		$title = pmpro_getLevel($level)->name;
-		
-	global $current_user, $membership_levels;
-
-	ob_start();	
-	?>
-		<?php if(empty($current_user->ID) || !pmpro_hasMembershipLevel($level,$current_user->ID)) { ?>
-		<form class="pmpro_form memberlite_signup" action="<?php echo pmpro_url("checkout", "?level=" . $level, "https"); ?>" method="post">
-			<h2><?php echo $title; ?></h2>
-			<?php
-				if(!empty($intro))
-					echo wpautop($intro);
-			?>
-			<input type="hidden" id="level" name="level" value="<?php echo esc_attr( $level ); ?>" />
-			<?php
-				if(!empty($current_user->ID))
-				{
-					?>
-					<p id="pmpro_account_loggedin">
-						<?php printf(__('You are logged in as <strong>%s</strong>. If you would like to use a different account for this membership, <a href="%s">log out now</a>.', 'memberlite-shortcodes'), $current_user->user_login, wp_logout_url($_SERVER['REQUEST_URI'])); ?>			
-					</p>
-					<?php
-				}
-				else
-				{
-					?>
-					<div>
-						<label for="username"><?php esc_html_e( 'Username', 'memberlite-shortcodes' ); ?></label>
-						<input id="username" name="username" type="text" class="input" size="30" value="" /> 
-					</div>
-					<?php do_action("pmpro_checkout_after_username");?>
-					<div>
-						<label for="password"><?php esc_html_e( 'Password', 'memberlite-shortcodes' ); ?></label>
-						<input id="password" name="password" type="password" class="input" size="30" value="" /> 
-					</div>
-					<?php if($short) { ?>
-						<input type="hidden" name="password2_copy" value="1" />
-					<?php } else { ?>
-						<div>
-							<label for="password2"><?php esc_html_e( 'Confirm Password', 'memberlite-shortcodes' ); ?></label>
-							<input id="password2" name="password2" type="password" class="input" size="30" value="" /> 
-						</div>			
-					<?php } ?>
-					<?php do_action("pmpro_checkout_after_password");?>
-					<div>
-						<label for="bemail"><?php esc_html_e( 'E-mail Address', 'memberlite-shortcodes' ); ?></label>
-						<input id="bemail" name="bemail" type="email" class="input" size="30" value="" /> 
-					</div>
-					<?php if($short) { ?>
-						<input type="hidden" name="bconfirmemail_copy" value="1" />
-					<?php } else { ?>
-						<div>
-							<label for="bconfirmemail"><?php esc_html_e( 'Confirm E-mail', 'memberlite-shortcodes' ); ?></label>
-							<input id="bconfirmemail" name="bconfirmemail" type="email" class="input" size="30" value="" /> 
-						</div>	         
-					<?php } ?>
-					<?php do_action("pmpro_checkout_after_email");?>
-					<div class="pmpro_hidden">
-						<label for="fullname"><?php esc_html_e( 'Full Name', 'memberlite-shortcodes' ); ?></label>
-						<input id="fullname" name="fullname" type="text" class="input" size="30" value="" /> <strong><?php esc_html_e( 'LEAVE THIS BLANK', 'memberlite-shortcodes' ); ?></strong>
-					</div>
-					
-					<div class="pmpro_captcha">
-						<?php 																								
-							global $recaptcha, $recaptcha_publickey;										
-							if($recaptcha == 2 || ($recaptcha == 1 && pmpro_isLevelFree($pmpro_level))) 
-							{											
-								echo recaptcha_get_html($recaptcha_publickey, NULL, true);						
-							}								
-						?>								
-					</div>
-					<?php
-				}
-			?>
-			<div>
-				<span id="pmpro_submit_span" >
-					<input type="hidden" name="submit-checkout" value="1" />		
-					<input type="submit" class="pmpro_btn pmpro_btn-submit-checkout" value="<?php echo esc_attr( $submit_button ); ?>" />
-				</span>
-			</div>	
-		</form>
-		<?php } ?>
-	<?php
-	$temp_content = ob_get_contents();
-	ob_end_clean();
-	return $temp_content;
+	// Show a message to admins that the shortcode is deprecated.
+	if ( current_user_can ( 'manage_options' ) ) {
+		return '<div class="pmpro_message pmpro_error">' . esc_html__( 'Admin only message: The Memberlite Signup shortcode is deprecated. Please update your content.', 'memberlite-shortcodes' ) . '</div>';
+	}
 }
 remove_shortcode('memberlite_signup');	//replace shortcode bundled with Memberlite 2.0 and prior or anywhere else
 add_shortcode("memberlite_signup", "memberlitesc_signup_shortcode");

--- a/shortcodes/signup.php
+++ b/shortcodes/signup.php
@@ -7,7 +7,7 @@
 */
 function memberlitesc_signup_shortcode($atts, $content=null, $code="")
 {
-	_doing_it_wrong( __FUNCTION__, __( 'The [memberlite_signup] shortcode is now deprecated. Please use the Signup Shortcode Add On for Paid Memberships Pro instead.', 'memberlite-shortcodes' ), '1.4' );
+	_doing_it_wrong( __FUNCTION__, esc_html__( 'The [memberlite_signup] shortcode is now deprecated. Please use the Signup Shortcode Add On for Paid Memberships Pro instead.', 'memberlite-shortcodes' ), '1.4' );
 
 	// Show a message to admins that the shortcode is deprecated.
 	if ( current_user_can ( 'manage_options' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/memberlite-shortcodes/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/memberlite-shortcodes/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Deprecated the Signup Shortcode in Memberlite. Sites should use the Paid Memberships Pro Signup Shortcode Add On instead.

Fixed a translations issue in the Recent Posts shortcode.

Fixed a security issue in the Accordion shortcode (thank you Peter Thaleikis).
